### PR TITLE
Make it possible to choose the original author who is not in the project (Issue #2)

### DIFF
--- a/lib/redmine_editauthor/hook.rb
+++ b/lib/redmine_editauthor/hook.rb
@@ -12,8 +12,11 @@ module RedmineEditauthor
         return if issue.new_record? || !User.current.allowed_to?(:edit_issue_author, project)
 
         content_tag(:p, id: 'editauthor') do
-          o = options_from_collection_for_select(possible_authors(issue.project).collect,
-                                                 'id', 'name', issue.author_id)
+          pas = possible_authors(issue.project)
+          if !pas.include? issue.author 
+            pas.unshift issue.author
+          end
+          o = options_from_collection_for_select(pas.collect, 'id', 'name', issue.author_id)
 
           concat label_tag('issue[author_id]', l(:field_author))
           concat select_tag('issue[author_id]', o)


### PR DESCRIPTION
Make it possible to choose the original author who is not in the project as the author.

With v0.9.1, When I moved some issue to another project, the "author" field was overwritten because that user is not registered as member of that project. 

This PR add the original author as an option.