### PR TITLE
Fix german translation

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,3 +1,3 @@
-en:
+de:
   permission_edit_issue_author: "Autor bearbeiten"
   permission_set_original_issue_author: "Autor bei Ticketerstellung auswählen"


### PR DESCRIPTION
Rename `en:` to `de:`