### PR TITLE
Improve issue speed

### DIFF
--- a/lib/redmine_editauthor.rb
+++ b/lib/redmine_editauthor.rb
@@ -1,6 +1,7 @@
 module RedmineEditauthor
   PATCHES = [
-    'Issue'
+    'Issue',
+    'Project'
   ]
 
   def self.patch

--- a/lib/redmine_editauthor/hook.rb
+++ b/lib/redmine_editauthor/hook.rb
@@ -17,7 +17,7 @@ module RedmineEditauthor
         author = issue.author
 
         content_tag(:p, id: 'editauthor') do
-          authors = possible_authors(issue.project)
+          authors = project.possible_authors
 
           authors.unshift(author) if author && !authors.include?(author)
 
@@ -34,7 +34,7 @@ module RedmineEditauthor
         return if project && !User.current.allowed_to?(:edit_issue_author, project)
 
         content_tag(:p, id: 'editauthor') do
-          authors = possible_authors(project)
+          authors = project.possible_authors
 
           o = content_tag('option', l(:label_no_change_option), :value => '') \
               + options_from_collection_for_select(authors, 'id', 'name')
@@ -53,13 +53,6 @@ module RedmineEditauthor
       end
 
       private
-
-      def possible_authors(project)
-        User.active.eager_load(:members).where(
-          "#{Member.table_name}.project_id = ? OR #{User.table_name}.admin = ?",
-          project.id, true
-        ).select { |u| u.allowed_to?(:add_issues, project) }
-      end
 
       def author_select_field(options)
         label_tag('issue[author_id]', l(:field_author)) \

--- a/lib/redmine_editauthor/patches/project_patch.rb
+++ b/lib/redmine_editauthor/patches/project_patch.rb
@@ -1,0 +1,28 @@
+module RedmineEditauthor
+  module Patches
+    module ProjectPatch
+      def self.included(base)
+        base.send(:include, InstanceMethods)
+        base.class_eval do
+          alias_method_chain :reload, :editauthor
+        end
+      end
+
+      module InstanceMethods
+        def possible_authors
+          return @possible_authors if @possible_authors
+
+          @possible_authors = User.active.eager_load(:members).where(
+            "#{Member.table_name}.project_id = ? OR #{User.table_name}.admin = ?",
+            id, true
+          ).select { |u| u.allowed_to?(:add_issues, self) }
+        end
+
+        def reload_with_editauthor(*args)
+          @possible_authors = nil
+          reload_without_editauthor(*args)
+        end 
+      end
+    end
+  end
+end


### PR DESCRIPTION
With editauthor plugin, the Issue display slowed down.
This is due to fetching user information every time Issue is displayed, and my Redmine has many many many users.

So I modify code to store "possible_authors" as member of the project.
Make fewer DB access and improve speed.