### PR TITLE
Fix bulk edit problem

### DIFF
--- a/lib/redmine_editauthor/hook.rb
+++ b/lib/redmine_editauthor/hook.rb
@@ -31,7 +31,7 @@ module RedmineEditauthor
       def view_issues_bulk_edit_details_bottom(context = {})
         project = context[:project]
 
-        return if project && !User.current.allowed_to?(:edit_issue_author, project)
+        return if !project || !User.current.allowed_to?(:edit_issue_author, project)
 
         content_tag(:p, id: 'editauthor') do
           authors = possible_authors(project)


### PR DESCRIPTION
When I tried to bulk edit issues belonging to different projects, I faced "Internal Server Error".

I fixed that problem. After this fix, you can change author in bulk edit only if the issues belong to the same project.