### PR TITLE
remove warning about an already initialized constant PLUGIN_ID and PA…

### DIFF
--- a/lib/redmine_editauthor.rb
+++ b/lib/redmine_editauthor.rb
@@ -1,7 +1,7 @@
 module RedmineEditauthor
-  PLUGIN_ID = :redmine_editauthor
+  PLUGIN_ID ||= :redmine_editauthor
 
-  PATCHES = [
+  PATCHES ||= [
     'Issue'
   ]
 


### PR DESCRIPTION
Remove warning about already initialized constant PLUGIN_ID and PATCHES by Use Conditional Assignment.
I am not an expert of ruby, but it seems to work.